### PR TITLE
Use keyword for string matching

### DIFF
--- a/autoload/asyncomplete/sources/neosnippet.vim
+++ b/autoload/asyncomplete/sources/neosnippet.vim
@@ -13,7 +13,7 @@ function! asyncomplete#sources#neosnippet#completor(opt, ctx)
     let l:col = a:ctx['col']
     let l:typed = a:ctx['typed']
 
-    let l:kw = matchstr(l:typed, '\w\+$')
+    let l:kw = matchstr(l:typed, '\k\+$')
     let l:kwlen = len(l:kw)
 
     let l:matches = map(l:snips,'{"word":v:val["word"],"dup":1,"icase":1,"menu": "[snip] " . v:val["menu_abbr"]}')


### PR DESCRIPTION
If I start typing something like `foo-b`, this starts showing matches for snippets matching just the `b` because the hyphen isn't counted here. Using `\k` (`iskeyword`) for matches rather than `\w` allows greater user control.