### PR TITLE
Fix completor

### DIFF
--- a/autoload/asyncomplete/sources/neosnippet.vim
+++ b/autoload/asyncomplete/sources/neosnippet.vim
@@ -6,7 +6,7 @@ function! asyncomplete#sources#neosnippet#get_source_options(opts)
 endfunction
 
 function! asyncomplete#sources#neosnippet#completor(opt, ctx)
-    let l:snips = values(neosnippet#helpers#get_completion_snippets())
+    let l:snips = neosnippet#helpers#get_completion_snippets()
 
     let l:matches = []
 


### PR DESCRIPTION
Hi. Thanks for asyncomplete.vim and asyncomplete-neosnippet.vim. They help me everyday.

Snippets haven't been shown as asyncomplete candidates since https://github.com/Shougo/neosnippet.vim/commit/5d07842911b485240719b781dfd7817b85c8eb96, which changed the return value of `neosnippet#helpers#get_completion_snippets` from a dictionary to a list. This pull request fixes the issue.

Best regards.